### PR TITLE
Added crossplane-azure-upbound Helm chart - New PR

### DIFF
--- a/charts/crossplane-azure-upbound/.helmignore
+++ b/charts/crossplane-azure-upbound/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.1.0"
+appVersion: "v1.0.0"

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: crossplane-azure-upbound
+description: A Helm chart for the Azure Provider for Crossplane
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 2.0.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.1.0"

--- a/charts/crossplane-azure-upbound/templates/_helpers.tpl
+++ b/charts/crossplane-azure-upbound/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "resources.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "resources.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "resources.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "resources.labels" -}}
+helm.sh/chart: {{ include "resources.chart" . }}
+{{ include "resources.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "resources.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "resources.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+

--- a/charts/crossplane-azure-upbound/templates/provider-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-config.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.global.enabled_azure_upbound .Values.providerConfig.enabled }}
+{{- with .Values.providerConfig }}
+apiVersion: azure.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: {{ .metadata.name }}   
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    helm.sh/hook: post-install
+    {{- range $key, $value := .metadata.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .metadata.labels }}
+  labels:
+    {{- range $key, $value := .metadata.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and .spec.clientID .spec.tenantID .spec.subscriptionID }}
+  credentials:
+    source: UserAssignedManagedIdentity
+  clientID: {{ .spec.clientID }}
+  subscriptionID: {{ .spec.subscriptionID }}
+  tenantID: {{ .spec.tenantID }}
+  {{- else }}
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: {{ .spec.credentials.secretRef.namespace }}
+      name: {{ .spec.credentials.secretRef.name }}
+      key: {{ .spec.credentials.secretRef.key }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/crossplane-azure-upbound/templates/provider-family.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-family.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.enabled_azure_upbound .Values.provider.enabled }}
+{{- with .Values.provider }}
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-family-azure
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    {{- range $key, $value := .metadata.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .metadata.labels }}
+  labels:
+    {{- range $key, $value := .metadata.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  package: {{ .package.registry }}/provider-family-azure:{{ .package.version }}
+{{- end }}
+{{- end }}

--- a/charts/crossplane-azure-upbound/templates/providers.yaml
+++ b/charts/crossplane-azure-upbound/templates/providers.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.global.enabled_azure_upbound .Values.provider.enabled }}
+{{- range .Values.providers }}
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-azure-{{ . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+    {{- range $key, $value := $.Values.provider.metadata.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if $.Values.provider.metadata.labels }}
+  labels:
+    {{- range $key, $value := $.Values.provider.metadata.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  package: {{ $.Values.provider.package.registry }}/provider-azure-{{ . }}:{{ $.Values.provider.package.version }}
+---
+{{- end }}
+
+{{- end }}
+

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.global.enabled_azure_upbound .Values.deploymentRuntimeConfig.enabled }}
+{{- with .Values.deploymentRuntimeConfig }}
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: {{ .metadata.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    {{- range $key, $value := .metadata.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+
+  {{- if .metadata.labels }}
+  labels:
+    {{- range $key, $value := .metadata.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  serviceAccountTemplate:
+    metadata:
+      {{- if .spec.serviceAccountTemplate.metadata.labels }}
+      labels:
+        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      annotations:
+        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      name: {{ .spec.serviceAccountTemplate.metadata.name }}
+  deploymentTemplate:
+  {{- .spec.deploymentTemplate | toYaml | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -1,0 +1,70 @@
+global:
+  enabled_azure_upbound: true
+
+deploymentRuntimeConfig:
+  enabled: false
+  metadata:
+    name: "upbound-azure-runtime-config"
+    role_arn: ""
+    annotations: {}
+    labels:
+      app.kubernetes.io/managed-by: Helm
+  spec:
+    deploymentTemplate:
+      spec:
+        selector: {}
+        template:
+          metadata:
+            annotations: {}
+            labels: 
+              azure.workload.identity/use: true
+          spec:
+            containers:
+              - name: package-runtime
+                args:
+                - --debug
+            securityContext:
+              fsGroup: 2000
+    serviceAccountTemplate:
+      metadata:
+        annotations: {}
+        labels:
+        name: azure-provider
+
+provider:
+  enabled: true
+  metadata:
+    annotations: {}
+    labels:
+      app.kubernetes.io/managed-by: Helm
+  package:
+    registry: xpkg.upbound.io/upbound
+    version: v0.42.0
+
+providerConfig:
+  enabled: true
+  metadata:
+    name: default
+    annotations: {}
+    labels:
+      app.kubernetes.io/managed-by: Helm
+  spec:
+    credentials:
+      source: Secret
+      secretRef:
+        namespace: crossplane-system
+        name: azure-secret
+        key: creds
+    
+providers:
+- network
+- compute
+- storage
+- authorization
+- containerservice
+- containerregistry
+- keyvault
+- operationalinsights
+- insights
+- managedidentity
+- resources


### PR DESCRIPTION
I added a new Helm chat in the crossplane-azure-upbound folder to install the Crossplane upbound packages for Azure. The ProviderConfig CRD supports both the service principal and managed identity credentials.