### PR TITLE
Added support for workload identity on the cross-azure-upbound chart

### DIFF
--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/templates/provider-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-config.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .spec.credentials.source .spec.credentials.clientID .spec.credentials.tenantID .spec.credentials.subscriptionID }}
+  {{- if and .spec.source .spec.clientID .spec.tenantID .spec.subscriptionID }}
   credentials:
     source: {{ .spec.credentials.source }}
   clientID: {{ .spec.clientID }}

--- a/charts/crossplane-azure-upbound/templates/provider-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-config.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   {{- if and .spec.source .spec.clientID .spec.tenantID .spec.subscriptionID }}
   credentials:
-    source: {{ .spec.credentials.source }}
+    source: {{ .spec.source }}
   clientID: {{ .spec.clientID }}
   subscriptionID: {{ .spec.subscriptionID }}
   tenantID: {{ .spec.tenantID }}

--- a/charts/crossplane-azure-upbound/templates/provider-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-config.yaml
@@ -18,9 +18,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .spec.clientID .spec.tenantID .spec.subscriptionID }}
+  {{- if and .spec.credentials.source .spec.credentials.clientID .spec.credentials.tenantID .spec.credentials.subscriptionID }}
   credentials:
-    source: UserAssignedManagedIdentity
+    source: {{ .spec.credentials.source }}
   clientID: {{ .spec.clientID }}
   subscriptionID: {{ .spec.subscriptionID }}
   tenantID: {{ .spec.tenantID }}

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -17,9 +17,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  serviceAccountTemplate:
-  {{- .spec.deploymentTemplate | toYaml | nindent 4 }}
   deploymentTemplate:
+  {{- .spec.deploymentTemplate | toYaml | nindent 4 }}  
+  serviceAccountTemplate:
   {{- .spec.serviceAccountTemplate | toYaml | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -17,9 +17,20 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  deploymentTemplate:
-  {{- .spec.deploymentTemplate | toYaml | nindent 4 }}  
   serviceAccountTemplate:
-  {{- .spec.serviceAccountTemplate | toYaml | nindent 4 }}
+    metadata:
+      {{- if .spec.serviceAccountTemplate.metadata.labels }}
+      labels:
+        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      annotations:
+        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      name: {{ .spec.serviceAccountTemplate.metadata.name }}
+  deploymentTemplate:
+  {{- .spec.deploymentTemplate | toYaml | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -25,10 +25,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
+      {{- if .spec.serviceAccountTemplate.metadata.annotations }}
       annotations:
         {{- range $key, $value := .spec.serviceAccountTemplate.metadata.annotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      {{- end }}
       name: {{ .spec.serviceAccountTemplate.metadata.name }}
   deploymentTemplate:
   {{- .spec.deploymentTemplate | toYaml | nindent 4 }}

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -18,19 +18,8 @@ metadata:
   {{- end }}
 spec:
   serviceAccountTemplate:
-    metadata:
-      {{- if .spec.serviceAccountTemplate.metadata.labels }}
-      labels:
-        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- end }}
-      annotations:
-        {{- range $key, $value := .spec.serviceAccountTemplate.metadata.annotations }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      name: {{ .spec.serviceAccountTemplate.metadata.name }}
-  deploymentTemplate:
   {{- .spec.deploymentTemplate | toYaml | nindent 4 }}
+  deploymentTemplate:
+  {{- .spec.serviceAccountTemplate | toYaml | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -4,7 +4,7 @@ global:
 deploymentRuntimeConfig:
   enabled: false
   metadata:
-    name: "upbound-azure-runtime-config"
+    name: "default"
     role_arn: ""
     annotations: {}
     labels:

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -30,6 +30,7 @@ deploymentRuntimeConfig:
         annotations: {}
         labels:
           azure.workload.identity/use: "true"
+        name: azure-provider
 
 provider:
   enabled: true

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -4,32 +4,29 @@ global:
 deploymentRuntimeConfig:
   enabled: false
   metadata:
-    name: "upbound-azure-runtime-config"
+    name: "default"
     role_arn: ""
     annotations: {}
     labels:
       app.kubernetes.io/managed-by: Helm
   spec:
     deploymentTemplate:
-      spec:
-        selector: {}
-        template:
-          metadata:
-            annotations: {}
-            labels: 
-              azure.workload.identity/use: true
-          spec:
-            containers:
-              - name: package-runtime
-                args:
-                - --debug
-            securityContext:
-              fsGroup: 2000
-    serviceAccountTemplate:
       metadata:
-        annotations: {}
         labels:
-        name: azure-provider
+          azure.workload.identity/use: "true"
+      spec:
+        replicas: 1
+        template:
+          securityContext:
+            fsGroup: 2000
+          containers:
+          - name: package-runtime
+            args:
+            - --debug
+    serviceAccountTemplate:
+      metadata: 
+        labels:
+            azure.workload.identity/use: "true"  
 
 provider:
   enabled: true

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -27,7 +27,6 @@ deploymentRuntimeConfig:
               fsGroup: 2000
     serviceAccountTemplate:
       metadata:
-        annotations: {}
         labels:
           azure.workload.identity/use: "true"
         name: azure-provider

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -26,7 +26,7 @@ deploymentRuntimeConfig:
     serviceAccountTemplate:
       metadata: 
         labels:
-            azure.workload.identity/use: "true"  
+          azure.workload.identity/use: "true"  
 
 provider:
   enabled: true

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -4,29 +4,32 @@ global:
 deploymentRuntimeConfig:
   enabled: false
   metadata:
-    name: "default"
+    name: "upbound-azure-runtime-config"
     role_arn: ""
     annotations: {}
     labels:
       app.kubernetes.io/managed-by: Helm
   spec:
     deploymentTemplate:
-      metadata:
-        labels:
-          azure.workload.identity/use: "true"
       spec:
-        replicas: 1
+        selector: {}
         template:
-          securityContext:
-            fsGroup: 2000
-          containers:
-          - name: package-runtime
-            args:
-            - --debug
+          metadata:
+            annotations: {}
+            labels: 
+              azure.workload.identity/use: true
+          spec:
+            containers:
+              - name: package-runtime
+                args:
+                - --debug
+            securityContext:
+              fsGroup: 2000
     serviceAccountTemplate:
-      metadata: 
+      metadata:
+        annotations: {}
         labels:
-          azure.workload.identity/use: "true"  
+        name: azure-provider
 
 provider:
   enabled: true

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -17,7 +17,7 @@ deploymentRuntimeConfig:
           metadata:
             annotations: {}
             labels: 
-              azure.workload.identity/use: true
+              azure.workload.identity/use: "true"
           spec:
             containers:
               - name: package-runtime
@@ -29,7 +29,7 @@ deploymentRuntimeConfig:
       metadata:
         annotations: {}
         labels:
-        name: azure-provider
+          azure.workload.identity/use: "true"
 
 provider:
   enabled: true


### PR DESCRIPTION
This PR is to add workload identity support to the crossplane azure chart as per the guidance https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md#alternatives-considered

Changes include 
- providerconfig to have the credential source to be updates through values.yaml
- updates to runtime config to inject the workloadidentity label to deployments and service accounts
- bumped the chart version to 1.1