### PR TITLE
Added support for workload identity on the cross-azure-upbound chart

### DIFF
--- a/charts/crossplane-azure-upbound/Chart.yaml
+++ b/charts/crossplane-azure-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-azure-upbound/templates/provider-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/provider-config.yaml
@@ -18,9 +18,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .spec.clientID .spec.tenantID .spec.subscriptionID }}
+  {{- if and .spec.source .spec.clientID .spec.tenantID .spec.subscriptionID }}
   credentials:
-    source: UserAssignedManagedIdentity
+    source: {{ .spec.source }}
   clientID: {{ .spec.clientID }}
   subscriptionID: {{ .spec.subscriptionID }}
   tenantID: {{ .spec.tenantID }}

--- a/charts/crossplane-azure-upbound/templates/runtime-config.yaml
+++ b/charts/crossplane-azure-upbound/templates/runtime-config.yaml
@@ -25,10 +25,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
+      {{- if .spec.serviceAccountTemplate.metadata.annotations }}
       annotations:
         {{- range $key, $value := .spec.serviceAccountTemplate.metadata.annotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      {{- end }}
       name: {{ .spec.serviceAccountTemplate.metadata.name }}
   deploymentTemplate:
   {{- .spec.deploymentTemplate | toYaml | nindent 4 }}

--- a/charts/crossplane-azure-upbound/values.yaml
+++ b/charts/crossplane-azure-upbound/values.yaml
@@ -4,7 +4,7 @@ global:
 deploymentRuntimeConfig:
   enabled: false
   metadata:
-    name: "upbound-azure-runtime-config"
+    name: "default"
     role_arn: ""
     annotations: {}
     labels:
@@ -17,7 +17,7 @@ deploymentRuntimeConfig:
           metadata:
             annotations: {}
             labels: 
-              azure.workload.identity/use: true
+              azure.workload.identity/use: "true"
           spec:
             containers:
               - name: package-runtime
@@ -29,6 +29,7 @@ deploymentRuntimeConfig:
       metadata:
         annotations: {}
         labels:
+          azure.workload.identity/use: "true"
         name: azure-provider
 
 provider:


### PR DESCRIPTION
This PR is to add workload identity support to the crossplane azure chart as per the guidance https://github.com/crossplane/crossplane/blob/master/design/one-pager-package-runtime-config.md#alternatives-considered

Changes include

- providerconfig to have the credential source to be updated through values.yaml
- updates to runtime config to inject the workload identity label to deployments and service accounts
- bumped the chart version to 1.1
