### PR TITLE
Use DeploymentRuntimeConfig for aws upbound family provider

### DIFF
--- a/charts/crossplane-aws-upbound/Chart.yaml
+++ b/charts/crossplane-aws-upbound/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crossplane-aws-upbound/templates/provider-family.yaml
+++ b/charts/crossplane-aws-upbound/templates/provider-family.yaml
@@ -18,7 +18,9 @@ metadata:
   {{- end }}
 spec:
   package: {{ .package.registry }}/provider-family-aws:{{ .package.version }}
-
-
+  runtimeConfigRef:
+    apiVersion: pkg.crossplane.io/v1beta1
+    kind: DeploymentRuntimeConfig
+    name: {{ $.Values.deploymentRuntimeConfig.metadata.name }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I really want to tweak tolerations for the family provider pod, so I decided to update provider definition to attach DeploymentRuntimeConfig